### PR TITLE
Fix HTTP client timeout option

### DIFF
--- a/src/Component/MoexIssComponent.php
+++ b/src/Component/MoexIssComponent.php
@@ -20,8 +20,8 @@ class MoexIssComponent implements MoexIssComponentInterface
     )
     {
         $this->httpClient = HttpClient::create([
+            'timeout' => 10,
             'headers' => [
-                'timeout' => 10,
                 'Accept' => 'application/json',
             ],
         ]);


### PR DESCRIPTION
## Summary
- fix timeout option for HTTP client configuration

## Testing
- `./bin/phpunit` *(fails: php not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849bd0052688320985ccb2b431333b7