### PR TITLE
Fix MCP command descriptions

### DIFF
--- a/src/Command/ClientCommand.php
+++ b/src/Command/ClientCommand.php
@@ -14,7 +14,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(
     name: 'app:mcp-client',
-    description: 'Протестировать mcp',
+    description: 'Протестировать MCP',
 )]
 class ClientCommand extends Command
 {

--- a/src/Command/ServerCommand.php
+++ b/src/Command/ServerCommand.php
@@ -19,7 +19,7 @@ use Symfony\Component\Console\Output\OutputInterface;
 
 #[AsCommand(
     name: 'app:mcp-server',
-    description: 'Протестировать mcp',
+    description: 'Протестировать MCP',
 )]
 class ServerCommand extends Command
 {


### PR DESCRIPTION
## Summary
- use proper capitalisation in MCP test command descriptions

## Testing
- `composer install --no-interaction` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6849bebd65408320b7dbba082cbcbd39