### PR TITLE
[codex] remove unused podman parameters

### DIFF
--- a/src/Command/ClientCommand.php
+++ b/src/Command/ClientCommand.php
@@ -27,16 +27,6 @@ class ClientCommand extends Command
     protected function execute(InputInterface $input, OutputInterface $output): int
     {
         $serverParams = new StdioServerParameters(
-            command: 'podman-compose',
-            args: [
-                'run',
-                '--rm',
-                'moex-mcp-server',
-                'bin/console',
-                'app:mcp-server',
-            ],
-        );
-        $serverParams = new StdioServerParameters(
             command: 'bin/console',
             args: [
                 'app:mcp-server',


### PR DESCRIPTION
### Summary
- clean up ClientCommand by removing old podman-compose params

### Testing
- `./bin/phpunit tests/Integration/Command/ServerCommandTest.php` *(fails: `/usr/bin/env: ‘php’: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_684a46b4d04c8320887b41116f7796f8