### PR TITLE
[codex] Ignore vendor in Docker context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -3,3 +3,4 @@ var/*
 !var/cache
 !var/log
 tests
+/vendor


### PR DESCRIPTION
### Summary
- add `vendor` directory to `.dockerignore`

### Testing
- `./bin/phpunit` *(fails: `/usr/bin/env: ‘php’: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_684a470f5cf4832089494800fa4bb3bc