### PR TITLE
[codex] Add missing security parameter tests

### DIFF
--- a/tests/Integration/Command/ServerCommandTest.php
+++ b/tests/Integration/Command/ServerCommandTest.php
@@ -121,4 +121,40 @@ class ServerCommandTest extends KernelTestCase
         $this->assertStringContainsString('marketdata', $resAsJson);
         $this->assertStringContainsString('Сбербанк', $resAsJson);
     }
+
+    public function testGetSecuritySpecificationWithoutSecurity(): void
+    {
+        $session = $this->startSession();
+        $res = $session->callTool('get_security_specification', []);
+        $this->assertTrue($res->isError);
+        $this->assertStringContainsString('Missing parameter', $res->content[0]->text);
+        $this->assertStringContainsString('security', $res->content[0]->text);
+    }
+
+    public function testGetSecurityIndicesWithoutSecurity(): void
+    {
+        $session = $this->startSession();
+        $res = $session->callTool('get_security_indices', []);
+        $this->assertTrue($res->isError);
+        $this->assertStringContainsString('Missing parameter', $res->content[0]->text);
+        $this->assertStringContainsString('security', $res->content[0]->text);
+    }
+
+    public function testGetSecurityAggregatesWithoutSecurity(): void
+    {
+        $session = $this->startSession();
+        $res = $session->callTool('get_security_aggregates', []);
+        $this->assertTrue($res->isError);
+        $this->assertStringContainsString('Missing parameter', $res->content[0]->text);
+        $this->assertStringContainsString('security', $res->content[0]->text);
+    }
+
+    public function testGetSecurityTradeDataWithoutSecurity(): void
+    {
+        $session = $this->startSession();
+        $res = $session->callTool('get_security_trade_data', []);
+        $this->assertTrue($res->isError);
+        $this->assertStringContainsString('Missing parameter', $res->content[0]->text);
+        $this->assertStringContainsString('security', $res->content[0]->text);
+    }
 }


### PR DESCRIPTION
### Summary
- extend `ServerCommandTest` with checks for the `security` parameter absence

### Testing
- `./bin/phpunit` *(fails: `/usr/bin/env: ‘php’: No such file or directory`)*

------
https://chatgpt.com/codex/tasks/task_e_684a4730ab448320b48712815a7d0647