### PR TITLE
[codex] Exclude var directory from image

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,6 +1,4 @@
 .git
-var/*
-!var/cache
-!var/log
+var/
 tests
 /vendor

--- a/Dockerfile
+++ b/Dockerfile
@@ -11,4 +11,6 @@ WORKDIR /app
 COPY composer.* ./
 RUN composer install --no-scripts --no-autoloader --no-interaction
 COPY . .
-RUN composer dump-autoload --optimize && composer run-script post-install-cmd
+RUN composer dump-autoload --optimize \
+    && composer run-script post-install-cmd \
+    && rm -rf var


### PR DESCRIPTION
### Summary
- обновили `.dockerignore` чтобы игнорировать каталог `var`
- удаляем `var` в конце сборки образа в `Dockerfile`

### Testing
- `./bin/phpunit` *(ожидается ошибка из-за отсутствия PHP)*


------
https://chatgpt.com/codex/tasks/task_e_684a4c225da483209fd79992c0b04283